### PR TITLE
Tagging to properties

### DIFF
--- a/db/property-tags.test.ts
+++ b/db/property-tags.test.ts
@@ -1,0 +1,178 @@
+import test from 'ava'
+import { CosmosClient } from '@azure/cosmos'
+import {
+	createDBInstance,
+	reader,
+	writer,
+	getAllPropertiesByTag,
+	countAllPropertiesByTag,
+} from './property-tags'
+
+// eslint-disable-next-line functional/prefer-readonly-type
+const fakeStore: Map<string, string> = new Map()
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const createStub = () =>
+	// eslint-disable-next-line functional/no-class
+	class Stub {
+		public readonly databases = {
+			createIfNotExists: async ({ id: database }: { readonly id: string }) => ({
+				database: {
+					containers: {
+						createIfNotExists: async ({
+							id: container,
+						}: {
+							readonly id: string
+						}) => ({
+							container: {
+								items: {
+									create: async (options: any) => {
+										return {
+											item: {
+												container: {
+													database: {
+														id: database,
+													},
+													id: container,
+												},
+											},
+											options,
+										}
+									},
+									query: ({ query, parameters }: any) => ({
+										fetchAll: async () => {
+											return {
+												resources: [
+													query.includes('VALUE COUNT')
+														? 1
+														: {
+																id: '0x01234567890',
+																tags: [parameters[0].value],
+														  },
+												],
+											}
+										},
+									}),
+									upsert: async (options: any) => {
+										fakeStore.set(options.id, options.tags)
+										return {
+											item: {
+												container: {
+													database: {
+														id: database,
+													},
+													id: container,
+												},
+											},
+											options,
+										}
+									},
+								},
+								item: (id: string) => ({
+									read: async () => {
+										return {
+											item: {
+												container: {
+													database: {
+														id: database,
+													},
+													id: container,
+												},
+											},
+											resource:
+												id === 'dummy-empty-id'
+													? null
+													: {
+															id,
+													  },
+										}
+									},
+									delete: async () => {
+										fakeStore.delete('id')
+										return {
+											item: {
+												container: {
+													database: {
+														id: database,
+													},
+													id: container,
+												},
+												id,
+											},
+										}
+									},
+								}),
+							},
+						}),
+					},
+				},
+			}),
+		}
+	}
+
+test('An instance of the database is created', async (t) => {
+	const instance = await createDBInstance(
+		(createStub() as unknown) as typeof CosmosClient,
+		{
+			database: 'dummy-database',
+			container: 'dummy-container',
+		},
+		process.env
+	)
+	const result = await instance.items.create({
+		id: 'dummy-id',
+		displayName: 'dummy-name',
+	})
+	t.is(result.item.container.database.id, 'dummy-database')
+	t.is(result.item.container.id, 'dummy-container')
+})
+
+test('insert new property tags data', async (t) => {
+	const propertyAddress = '0x01234567890'
+	const result = await writer((createStub() as unknown) as typeof CosmosClient)(
+		{
+			id: propertyAddress,
+			tags: [],
+		}
+	)
+	t.is(result.item.container.database.id, 'Stakes.social')
+	t.is(result.item.container.id, 'PropertyTags')
+	t.deepEqual((result as any).options, {
+		id: propertyAddress,
+		tags: [],
+	})
+	t.is(fakeStore.get(propertyAddress)?.length, 0)
+
+	await writer((createStub() as unknown) as typeof CosmosClient)({
+		id: propertyAddress,
+		tags: ['a', 'b'],
+	})
+	t.is(fakeStore.get(propertyAddress)?.length, 2)
+})
+
+test('read property tags data', async (t) => {
+	const propertyAddress = '0x01234567890'
+	const result = await reader((createStub() as unknown) as typeof CosmosClient)(
+		propertyAddress
+	)
+	t.is(result.item.container.database.id, 'Stakes.social')
+	t.is(result.item.container.id, 'PropertyTags')
+	t.is(result.resource?.id, propertyAddress)
+})
+
+test('search property tags by tag', async (t) => {
+	const propertyAddress = '0x01234567890'
+	const tag = 'dummy-tag'
+	const result = await getAllPropertiesByTag(
+		(createStub() as unknown) as typeof CosmosClient
+	)(tag)
+	t.deepEqual(result.resources, [{ id: propertyAddress, tags: [tag] }])
+})
+
+test('count property tags by tag', async (t) => {
+	const tag = 'dummy-tag'
+	const result = await countAllPropertiesByTag(
+		(createStub() as unknown) as typeof CosmosClient
+	)(tag)
+	t.is(result, 1)
+})

--- a/db/property-tags.ts
+++ b/db/property-tags.ts
@@ -67,3 +67,19 @@ export const getAllPropertiesByTag = (client: typeof CosmosClient) => async (
 		})
 		.fetchAll()
 }
+
+export const countAllPropertiesByTag = (client: typeof CosmosClient) => async (
+	tag: string
+): Promise<number> => {
+	const container = await createDBInstance(client, COSMOS, process.env)
+	return container.items
+		.query<number>({
+			query:
+				'SELECT VALUE COUNT(p.id) FROM PropertyTags p WHERE ARRAY_CONTAINS(p.tags, @p1)',
+			parameters: [{ name: '@p1', value: tag }],
+		})
+		.fetchAll()
+		.then((r) => {
+			return r.resources[0]
+		})
+}

--- a/db/property-tags.ts
+++ b/db/property-tags.ts
@@ -1,0 +1,69 @@
+import {
+	CosmosClient,
+	Container,
+	FeedResponse,
+	ItemResponse,
+} from '@azure/cosmos'
+
+export type PropertyTags = {
+	readonly id: string // property address
+	// eslint-disable-next-line functional/no-mixed-type
+	readonly tags: readonly string[]
+}
+
+const COSMOS = {
+	database: 'Stakes.social',
+	container: 'PropertyTags',
+}
+
+export const createDBInstance = async (
+	Client: typeof CosmosClient,
+	opts: {
+		readonly database: string
+		readonly container: string
+	},
+	env: NodeJS.ProcessEnv
+): Promise<Container> => {
+	const { DB_ENDPOINT: endpoint = '', DB_MASTER_KEY: key = '' } = env
+	const client = new Client({ endpoint, key })
+	const { database } = await client.databases.createIfNotExists({
+		id: opts.database,
+	})
+	const { container } = await database.containers.createIfNotExists({
+		id: opts.container,
+	})
+	return container
+}
+
+export const writer = (client: typeof CosmosClient) => async (
+	data: PropertyTags
+): Promise<ItemResponse<PropertyTags>> => {
+	// ignore empty string
+	const writeData = {
+		...data,
+		tags: data.tags.filter((t: string) => t !== ''),
+	}
+
+	const container = await createDBInstance(client, COSMOS, process.env)
+	return container.items.upsert<PropertyTags>(writeData)
+}
+
+export const reader = (client: typeof CosmosClient) => async (
+	id: string
+): Promise<ItemResponse<PropertyTags>> => {
+	const container = await createDBInstance(client, COSMOS, process.env)
+	return container.item(id).read()
+}
+
+export const getAllPropertiesByTag = (client: typeof CosmosClient) => async (
+	tag: string
+): Promise<FeedResponse<PropertyTags>> => {
+	const container = await createDBInstance(client, COSMOS, process.env)
+	return container.items
+		.query<PropertyTags>({
+			query:
+				'SELECT p.id, p.tags FROM PropertyTags p WHERE ARRAY_CONTAINS(p.tags, @p1)',
+			parameters: [{ name: '@p1', value: tag }],
+		})
+		.fetchAll()
+}

--- a/db/tag.test.ts
+++ b/db/tag.test.ts
@@ -1,0 +1,181 @@
+import test from 'ava'
+import { CosmosClient } from '@azure/cosmos'
+import {
+	createDBInstance,
+	reader,
+	writer,
+	deleteTag,
+	getTagsByWordWithForwardMatch,
+} from './tag'
+
+// eslint-disable-next-line functional/prefer-readonly-type
+const fakeStore: Map<string, string> = new Map()
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const createStub = () =>
+	// eslint-disable-next-line functional/no-class
+	class Stub {
+		public readonly databases = {
+			createIfNotExists: async ({ id: database }: { readonly id: string }) => ({
+				database: {
+					containers: {
+						createIfNotExists: async ({
+							id: container,
+						}: {
+							readonly id: string
+						}) => ({
+							container: {
+								items: {
+									create: async (options: any) => {
+										return {
+											item: {
+												container: {
+													database: {
+														id: database,
+													},
+													id: container,
+												},
+											},
+											options,
+										}
+									},
+									query: ({ parameters }: any) => ({
+										fetchAll: async () => {
+											return {
+												resources: [{ id: parameters[0].value }],
+											}
+										},
+									}),
+									upsert: async (options: any) => {
+										return {
+											item: {
+												container: {
+													database: {
+														id: database,
+													},
+													id: container,
+												},
+											},
+											options,
+										}
+									},
+								},
+								item: (id: string) => ({
+									read: async () => {
+										return {
+											item: {
+												container: {
+													database: {
+														id: database,
+													},
+													id: container,
+												},
+												id,
+											},
+											resource:
+												id === 'dummy-empty-id'
+													? null
+													: {
+															id,
+													  },
+										}
+									},
+									delete: async () => {
+										fakeStore.delete('id')
+										return {
+											item: {
+												container: {
+													database: {
+														id: database,
+													},
+													id: container,
+												},
+												id,
+											},
+										}
+									},
+								}),
+							},
+						}),
+					},
+				},
+			}),
+		}
+	}
+
+test('An instance of the database is created', async (t) => {
+	const instance = await createDBInstance(
+		(createStub() as unknown) as typeof CosmosClient,
+		{
+			database: 'dummy-database',
+			container: 'dummy-container',
+		},
+		process.env
+	)
+	const result = await instance.items.create({
+		id: 'dummy-id',
+		displayName: 'dummy-name',
+	})
+	t.is(result.item.container.database.id, 'dummy-database')
+	t.is(result.item.container.id, 'dummy-container')
+})
+
+test('insert new tag data', async (t) => {
+	const result = await writer((createStub() as unknown) as typeof CosmosClient)(
+		{
+			id: 'dummy-tag',
+		}
+	)
+	t.is(result.item.container.database.id, 'Stakes.social')
+	t.is(result.item.container.id, 'Tag')
+	t.deepEqual((result as any).options, {
+		id: 'dummy-tag',
+	})
+})
+
+test('upsert tag data', async (t) => {
+	await writer((createStub() as unknown) as typeof CosmosClient)({
+		id: 'dummy-tag',
+	})
+	const result = await writer((createStub() as unknown) as typeof CosmosClient)(
+		{
+			id: 'dummy-tag2',
+		}
+	)
+	t.is(result.item.container.database.id, 'Stakes.social')
+	t.is(result.item.container.id, 'Tag')
+	t.deepEqual((result as any).options, {
+		id: 'dummy-tag2',
+	})
+})
+
+test('read tag data', async (t) => {
+	const result = await reader((createStub() as unknown) as typeof CosmosClient)(
+		'dummy-tag'
+	)
+	t.is(result.item.container.database.id, 'Stakes.social')
+	t.is(result.item.container.id, 'Tag')
+	t.is(result.resource?.id, 'dummy-tag')
+})
+
+test('delete tag data', async (t) => {
+	const tag = 'dummy-tag'
+	fakeStore.set('id', tag) as any
+
+	const result = await deleteTag(
+		(createStub() as unknown) as typeof CosmosClient
+	)(tag)
+	t.is(result.item.container.database.id, 'Stakes.social')
+	t.is(result.item.container.id, 'Tag')
+
+	t.is(fakeStore.get('id'), undefined)
+})
+
+test('search tag data with forward match', async (t) => {
+	const tag = 'dummy-tag'
+
+	const result = await getTagsByWordWithForwardMatch(
+		(createStub() as unknown) as typeof CosmosClient
+	)(tag)
+	t.deepEqual(result.resources, [{ id: tag }])
+})

--- a/db/tag.ts
+++ b/db/tag.ts
@@ -6,7 +6,7 @@ import {
 } from '@azure/cosmos'
 
 export type Tag = {
-	readonly name: string
+	readonly id: string // tag name is primary id
 }
 
 const COSMOS = {
@@ -41,10 +41,17 @@ export const writer = (client: typeof CosmosClient) => async (
 }
 
 export const reader = (client: typeof CosmosClient) => async (
+	id: string
+): Promise<ItemResponse<Tag>> => {
+	const container = await createDBInstance(client, COSMOS, process.env)
+	return container.item(id).read()
+}
+
+export const deleteTag = (client: typeof CosmosClient) => async (
 	name: string
 ): Promise<ItemResponse<Tag>> => {
 	const container = await createDBInstance(client, COSMOS, process.env)
-	return container.item(name).read()
+	return container.item(name).delete()
 }
 
 export const existTag = (client: typeof CosmosClient) => async (
@@ -59,7 +66,7 @@ export const getTagsByWordWithForwardMatch = (
 	const container = await createDBInstance(client, COSMOS, process.env)
 	return container.items
 		.query<Tag>({
-			query: 'SELECT t.name FROM Tag t WHERE STARTSWITH(t.name, @p1)',
+			query: 'SELECT t.id FROM Tag t WHERE STARTSWITH(t.id, @p1)',
 			parameters: [{ name: '@p1', value: word }],
 		})
 		.fetchAll()

--- a/db/tag.ts
+++ b/db/tag.ts
@@ -1,0 +1,49 @@
+import { CosmosClient, Container, ItemResponse } from '@azure/cosmos'
+
+export type Tag = {
+	readonly name: string
+}
+
+const COSMOS = {
+	database: 'Stakes.social',
+	container: 'Tag',
+}
+
+export const createDBInstance = async (
+	Client: typeof CosmosClient,
+	opts: {
+		readonly database: string
+		readonly container: string
+	},
+	env: NodeJS.ProcessEnv
+): Promise<Container> => {
+	const { DB_ENDPOINT: endpoint = '', DB_MASTER_KEY: key = '' } = env
+	const client = new Client({ endpoint, key })
+	const { database } = await client.databases.createIfNotExists({
+		id: opts.database,
+	})
+	const { container } = await database.containers.createIfNotExists({
+		id: opts.container,
+	})
+	return container
+}
+
+export const writer = (client: typeof CosmosClient) => async (
+	data: Tag
+): Promise<ItemResponse<Tag>> => {
+	const container = await createDBInstance(client, COSMOS, process.env)
+	return container.items.upsert<Tag>(data)
+}
+
+export const reader = (client: typeof CosmosClient) => async (
+	name: string
+): Promise<ItemResponse<Tag>> => {
+	const container = await createDBInstance(client, COSMOS, process.env)
+	return container.item(name).read()
+}
+
+export const existTag = (client: typeof CosmosClient) => async (
+	name: string
+): Promise<boolean> => {
+	return reader(client)(name) !== null
+}

--- a/db/tag.ts
+++ b/db/tag.ts
@@ -54,12 +54,6 @@ export const deleteTag = (client: typeof CosmosClient) => async (
 	return container.item(name).delete()
 }
 
-export const existTag = (client: typeof CosmosClient) => async (
-	name: string
-): Promise<boolean> => {
-	return reader(client)(name) !== null
-}
-
 export const getTagsByWordWithForwardMatch = (
 	client: typeof CosmosClient
 ) => async (word: string): Promise<FeedResponse<Tag>> => {

--- a/db/tag.ts
+++ b/db/tag.ts
@@ -1,4 +1,9 @@
-import { CosmosClient, Container, ItemResponse } from '@azure/cosmos'
+import {
+	CosmosClient,
+	Container,
+	FeedResponse,
+	ItemResponse,
+} from '@azure/cosmos'
 
 export type Tag = {
 	readonly name: string
@@ -46,4 +51,16 @@ export const existTag = (client: typeof CosmosClient) => async (
 	name: string
 ): Promise<boolean> => {
 	return reader(client)(name) !== null
+}
+
+export const getTagsByWordWithForwardMatch = (
+	client: typeof CosmosClient
+) => async (word: string): Promise<FeedResponse<Tag>> => {
+	const container = await createDBInstance(client, COSMOS, process.env)
+	return container.items
+		.query<Tag>({
+			query: 'SELECT t.name FROM Tag t WHERE STARTSWITH(t.name, @p1)',
+			parameters: [{ name: '@p1', value: word }],
+		})
+		.fetchAll()
 }

--- a/property-search-tags/function.json
+++ b/property-search-tags/function.json
@@ -1,0 +1,18 @@
+{
+	"bindings": [
+		{
+			"authLevel": "anonymous",
+			"type": "httpTrigger",
+			"direction": "in",
+			"name": "req",
+			"methods": ["post"],
+			"route": "{network}/properties/search/tags"
+		},
+		{
+			"type": "http",
+			"direction": "out",
+			"name": "res"
+		}
+	],
+	"scriptFile": "../dist/property-search-tags/index.js"
+}

--- a/property-search-tags/index.test.ts
+++ b/property-search-tags/index.test.ts
@@ -1,0 +1,101 @@
+import test from 'ava'
+import { stub } from 'sinon'
+import { Context, HttpRequest } from '@azure/functions'
+import { httpTrigger } from '.'
+import * as db from '../db/property-tags'
+
+stub(db, 'reader').callsFake(() => async (id: string) => {
+	return {
+		resource: {
+			id,
+			displayName: 'req-dummy-address-name',
+		},
+	} as any
+})
+stub(db, 'writer').callsFake(() => async (data: db.PropertyTags) => {
+	return {
+		resource: data,
+	} as any
+})
+stub(db, 'getAllPropertiesByTag').callsFake(() => async (tag: string) => {
+	return {
+		resources: [
+			{
+				id: '0x01234567890',
+				tags: [tag, 'dummy'],
+			},
+		],
+	} as any
+})
+
+const createContext = (): Context =>
+	(({
+		res: {},
+		log: () => {
+			// fake logger
+		},
+	} as unknown) as Context)
+
+const createReq = (tags: string, method = 'POST'): HttpRequest =>
+	(({
+		method,
+		body: {
+			tags,
+		},
+	} as unknown) as HttpRequest)
+
+test('search property tags data', async (t) => {
+	const context = createContext()
+	const tags = 'test dummy'
+
+	await httpTrigger(context, createReq(tags))
+
+	t.deepEqual(context.res, {
+		status: 200,
+		body: {
+			result: [
+				{
+					id: '0x01234567890',
+					tags: tags.split(' '),
+				},
+			],
+		},
+	})
+})
+
+test('search property tags with empty body data', async (t) => {
+	const context = createContext()
+	const tags = ''
+
+	await httpTrigger(context, createReq(tags))
+
+	t.deepEqual(context.res, {
+		status: 400,
+		body: '',
+	})
+})
+
+test('search property tags with blank body data', async (t) => {
+	const context = createContext()
+	const tags = ' '
+
+	await httpTrigger(context, createReq(tags))
+
+	t.deepEqual(context.res, {
+		status: 400,
+		body: '',
+	})
+})
+
+test('failure to get access', async (t) => {
+	const context = createContext()
+	const tags = 'test dummy'
+	const method = 'GET'
+
+	await httpTrigger(context, createReq(tags, method))
+
+	t.deepEqual(context.res, {
+		status: 400,
+		body: '',
+	})
+})

--- a/property-search-tags/index.ts
+++ b/property-search-tags/index.ts
@@ -1,0 +1,36 @@
+/* eslint-disable functional/no-conditional-statement */
+import { AzureFunction, Context, HttpRequest } from '@azure/functions'
+import { CosmosClient } from '@azure/cosmos'
+import { PropertyTags, getAllPropertiesByTag } from '../db/property-tags'
+import { responseCreator } from '../utils'
+
+export const httpTrigger: AzureFunction = async function (
+	context: Context,
+	req: HttpRequest
+): Promise<void> {
+	const resp = responseCreator(context)
+	const { method } = req
+
+	if (method !== 'POST') {
+		return resp(400)
+	}
+
+	const { tags = '' } = req.body
+
+	if (tags === '') {
+		return resp(400)
+	}
+
+	// get search word
+	// NOTE: Currently, you can only specify one search tag name
+	const tag = tags.split(' ')[0]
+
+	// check only blank
+	if (tag === '') {
+		return resp(400)
+	}
+
+	const results = await getAllPropertiesByTag(CosmosClient)(tag)
+
+	return resp(200, { result: results.resources as readonly PropertyTags[] })
+}

--- a/property-search-tags/index.ts
+++ b/property-search-tags/index.ts
@@ -22,7 +22,7 @@ export const httpTrigger: AzureFunction = async function (
 	}
 
 	// get search word
-	// NOTE: Currently, you can only specify one search tag name
+	// NOTE: can only specify one search tag name, now.
 	const tag = tags.split(' ')[0]
 
 	// check only blank
@@ -30,7 +30,7 @@ export const httpTrigger: AzureFunction = async function (
 		return resp(400)
 	}
 
-	const results = await getAllPropertiesByTag(CosmosClient)(tag)
+	const result = await getAllPropertiesByTag(CosmosClient)(tag)
 
-	return resp(200, { result: results.resources as readonly PropertyTags[] })
+	return resp(200, { result: result.resources as readonly PropertyTags[] })
 }

--- a/property-tags/function.json
+++ b/property-tags/function.json
@@ -1,0 +1,18 @@
+{
+	"bindings": [
+		{
+			"authLevel": "anonymous",
+			"type": "httpTrigger",
+			"direction": "in",
+			"name": "req",
+			"methods": ["get", "post"],
+			"route": "{network}/property/{id}/tags"
+		},
+		{
+			"type": "http",
+			"direction": "out",
+			"name": "res"
+		}
+	],
+	"scriptFile": "../dist/property-tags/index.js"
+}

--- a/property-tags/index.test.ts
+++ b/property-tags/index.test.ts
@@ -1,0 +1,178 @@
+import test from 'ava'
+import { stub } from 'sinon'
+import { Context, HttpRequest } from '@azure/functions'
+import Web3 from 'web3'
+import { httpTrigger } from '.'
+import * as db from '../db/property-tags'
+import * as tagDB from '../db/tag'
+
+stub(db, 'reader').callsFake(() => async (id: string) => {
+	return {
+		resource: {
+			id,
+			tags: ['test', 'dummy'],
+		},
+	} as any
+})
+stub(db, 'writer').callsFake(() => async (data: db.PropertyTags) => {
+	return {
+		resource: data,
+	} as any
+})
+stub(db, 'countAllPropertiesByTag').callsFake(() => async () => {
+	return 1
+})
+stub(tagDB, 'writer').callsFake(() => async (data: tagDB.Tag) => {
+	return {
+		resources: data,
+	} as any
+})
+
+const createContext = (): Context =>
+	(({
+		res: {},
+		log: () => {
+			// fake logger
+		},
+	} as unknown) as Context)
+
+const createReq = (
+	propertyAddress?: string,
+	accountAddress?: string,
+	message?: string,
+	signature?: string,
+	tags?: string,
+	method = 'GET'
+): HttpRequest =>
+	(({
+		method,
+		params: {
+			id: propertyAddress,
+		},
+		body: {
+			account: accountAddress,
+			message,
+			signature,
+			tags,
+		},
+	} as unknown) as HttpRequest)
+
+const prepare = (): {
+	readonly address: string
+	readonly signature: string
+	readonly message: string
+} => {
+	const web3 = new Web3()
+	const account = web3.eth.accounts.create()
+	const message = 'sign message'
+	const { signature } = account.sign(message)
+	const address = account.address
+	return {
+		address,
+		signature,
+		message,
+	}
+}
+
+test('get property tags data', async (t) => {
+	const context = createContext()
+	const propertyAddress = '0x01234567890'
+
+	await httpTrigger(context, createReq(propertyAddress))
+
+	t.deepEqual(context.res, {
+		status: 200,
+		body: {
+			id: propertyAddress,
+			tags: ['test', 'dummy'],
+		},
+	})
+})
+
+test('post peoperty tags data', async (t) => {
+	const { address: accountAddress, signature, message } = prepare()
+	const context = createContext()
+	const method = 'POST'
+	const propertyAddress = '0x01234567890'
+	const tags = 'test dummy'
+
+	await httpTrigger(
+		context,
+		createReq(propertyAddress, accountAddress, message, signature, tags, method)
+	)
+
+	t.deepEqual(context.res, {
+		status: 200,
+		body: {
+			id: propertyAddress,
+			tags: tags.split(' '),
+		},
+	})
+})
+
+test('failure post request with invalid signature', async (t) => {
+	const { address: accountAddress, message } = prepare()
+	const context = createContext()
+	const method = 'POST'
+	const propertyAddress = '0x01234567890'
+	const tags = 'test dummy'
+	const invalidSignature =
+		'0xde3857695618adfc20f598d59dc1fdfc820653e1affb2d16ccb5cf1821ead75a13d6b2cb50579bbec1d0a314ee417a356d6f3db389ce0a055e6badd03bbc50aaaa'
+
+	await httpTrigger(
+		context,
+		createReq(
+			propertyAddress,
+			accountAddress,
+			message,
+			invalidSignature,
+			tags,
+			method
+		)
+	)
+
+	t.deepEqual(context.res, {
+		status: 400,
+		body: '',
+	})
+})
+
+test('invalid post request with empty request body', async (t) => {
+	const { address: accountAddress, signature, message } = prepare()
+	const context = createContext()
+	const method = 'POST'
+	const propertyAddress = '0x01234567890'
+	const tags = 'test dummy'
+
+	const testExec = async (
+		accountAddress?: string,
+		message?: string,
+		signature?: string,
+		tags?: string
+	): Promise<void> => {
+		await httpTrigger(
+			context,
+			createReq(
+				propertyAddress,
+				accountAddress,
+				message,
+				signature,
+				tags,
+				method
+			)
+		)
+
+		t.deepEqual(context.res, {
+			status: 400,
+			body: '',
+		})
+	}
+
+	const params = [
+		{ accountAddress, message, tags },
+		{ accountAddress, message, signature },
+		{ accountAddress, signature, tags },
+		{ message, signature, tags },
+	]
+	params.map((p) => testExec(p.accountAddress, p.message, p.signature, p.tags))
+})

--- a/property-tags/index.ts
+++ b/property-tags/index.ts
@@ -1,8 +1,39 @@
 /* eslint-disable functional/no-conditional-statement */
+/* eslint-disable functional/no-expression-statement  */
 import { AzureFunction, Context, HttpRequest } from '@azure/functions'
-import { CosmosClient } from '@azure/cosmos'
-import { PropertyTags, reader, writer } from '../db/property-tags'
+import { CosmosClient, ItemResponse } from '@azure/cosmos'
+import {
+	PropertyTags,
+	countAllPropertiesByTag,
+	reader,
+	writer,
+} from '../db/property-tags'
+import { deleteTag, writer as tagWriter } from '../db/tag'
 import { responseCreator } from '../utils'
+
+const updateTags = async (
+	ctx: Context,
+	oldTags: readonly string[],
+	newTags: readonly string[]
+): Promise<void> => {
+	// update tags
+	await Promise.all(
+		newTags.map(async (tag: string) => {
+			return tagWriter(CosmosClient)({ id: tag })
+		})
+	)
+
+	// delete not related tags
+	await Promise.all(
+		oldTags.map(async (tag: string) => {
+			return await countAllPropertiesByTag(CosmosClient)(tag).then((count) => {
+				if (count === 0) {
+					return deleteTag(CosmosClient)(tag)
+				}
+			})
+		})
+	)
+}
 
 export const httpTrigger: AzureFunction = async function (
 	context: Context,
@@ -14,13 +45,22 @@ export const httpTrigger: AzureFunction = async function (
 	const { tags = '' } = method === 'POST' ? req.body : {}
 
 	const data = async (method: string | null): Promise<PropertyTags> => {
+		const result = await reader(CosmosClient)(id)
+		const readTags = result.resource as PropertyTags
+
 		if (method === 'POST') {
-			const splitedTags = tags.split(' ')
-			const result = await writer(CosmosClient)({ id, tags: splitedTags })
+			const splitedTags = tags.split(' ').filter((t: string) => t !== '')
+			const result = await writer(CosmosClient)({ id, tags: splitedTags }).then(
+				(r: ItemResponse<PropertyTags>) => {
+					// eslint-disable-next-line functional/functional-parameters
+					return updateTags(context, readTags.tags, splitedTags).then(() => {
+						return r
+					})
+				}
+			)
 			return result.resource as PropertyTags
 		} else {
-			const result = await reader(CosmosClient)(id)
-			return result.resource as PropertyTags
+			return readTags
 		}
 	}
 

--- a/property-tags/index.ts
+++ b/property-tags/index.ts
@@ -12,7 +12,6 @@ import { deleteTag, writer as tagWriter } from '../db/tag'
 import { responseCreator } from '../utils'
 
 const updateTags = async (
-	ctx: Context,
 	oldTags: readonly string[],
 	newTags: readonly string[]
 ): Promise<void> => {
@@ -53,7 +52,7 @@ export const httpTrigger: AzureFunction = async function (
 			const result = await writer(CosmosClient)({ id, tags: splitedTags }).then(
 				(r: ItemResponse<PropertyTags>) => {
 					// eslint-disable-next-line functional/functional-parameters
-					return updateTags(context, readTags.tags, splitedTags).then(() => {
+					return updateTags(readTags?.tags, splitedTags).then(() => {
 						return r
 					})
 				}

--- a/property-tags/index.ts
+++ b/property-tags/index.ts
@@ -1,0 +1,28 @@
+/* eslint-disable functional/no-conditional-statement */
+import { AzureFunction, Context, HttpRequest } from '@azure/functions'
+import { CosmosClient } from '@azure/cosmos'
+import { PropertyTags, reader, writer } from '../db/property-tags'
+import { responseCreator } from '../utils'
+
+export const httpTrigger: AzureFunction = async function (
+	context: Context,
+	req: HttpRequest
+): Promise<void> {
+	const resp = responseCreator(context)
+	const { method } = req
+	const { id } = req.params
+	const { tags = '' } = method === 'POST' ? req.body : {}
+
+	const data = async (method: string | null): Promise<PropertyTags> => {
+		if (method === 'POST') {
+			const splitedTags = tags.split(' ')
+			const result = await writer(CosmosClient)({ id, tags: splitedTags })
+			return result.resource as PropertyTags
+		} else {
+			const result = await reader(CosmosClient)(id)
+			return result.resource as PropertyTags
+		}
+	}
+
+	return resp(200, ((await data(method)) || {}) as PropertyTags)
+}

--- a/tags/function.json
+++ b/tags/function.json
@@ -1,0 +1,18 @@
+{
+	"bindings": [
+		{
+			"authLevel": "anonymous",
+			"type": "httpTrigger",
+			"direction": "in",
+			"name": "req",
+			"methods": ["get"],
+			"route": "{network}/tags"
+		},
+		{
+			"type": "http",
+			"direction": "out",
+			"name": "res"
+		}
+	],
+	"scriptFile": "../dist/tags/index.js"
+}

--- a/tags/index.test.ts
+++ b/tags/index.test.ts
@@ -1,0 +1,58 @@
+import test from 'ava'
+import { stub } from 'sinon'
+import { Context, HttpRequest } from '@azure/functions'
+import { httpTrigger } from '.'
+import * as db from '../db/tag'
+
+stub(db, 'reader').callsFake(() => async (id: string) => {
+	return {
+		resource: {
+			id,
+		},
+	} as any
+})
+stub(db, 'writer').callsFake(() => async (data: db.Tag) => {
+	return {
+		resource: data,
+	} as any
+})
+stub(db, 'getTagsByWordWithForwardMatch').callsFake(
+	() => async (word: string) => {
+		return {
+			resources: [{ id: `${word}-tag` }],
+		} as any
+	}
+)
+
+const createContext = (): Context =>
+	(({
+		res: {},
+		log: () => {
+			// fake logger
+		},
+	} as unknown) as Context)
+
+const createReq = (searchWord?: string, method = 'GET'): HttpRequest =>
+	(({
+		method,
+		query: {
+			w: searchWord || 'test',
+		},
+	} as unknown) as HttpRequest)
+
+test('get tags data', async (t) => {
+	const context = createContext()
+
+	await httpTrigger(context, createReq())
+
+	t.deepEqual(context.res, {
+		status: 200,
+		body: {
+			result: [
+				{
+					id: 'test-tag',
+				},
+			],
+		},
+	})
+})

--- a/tags/index.ts
+++ b/tags/index.ts
@@ -1,0 +1,17 @@
+/* eslint-disable functional/no-conditional-statement */
+import { AzureFunction, Context, HttpRequest } from '@azure/functions'
+import { CosmosClient } from '@azure/cosmos'
+import { Tag, getTagsByWordWithForwardMatch } from '../db/tag'
+import { responseCreator } from '../utils'
+
+export const httpTrigger: AzureFunction = async function (
+	context: Context,
+	req: HttpRequest
+): Promise<void> {
+	const resp = responseCreator(context)
+	const { w: searchWord } = req.params
+
+	const result = await getTagsByWordWithForwardMatch(CosmosClient)(searchWord)
+
+	return resp(200, { result: result.resources as readonly Tag[] })
+}

--- a/tags/index.ts
+++ b/tags/index.ts
@@ -9,7 +9,7 @@ export const httpTrigger: AzureFunction = async function (
 	req: HttpRequest
 ): Promise<void> {
 	const resp = responseCreator(context)
-	const { w: searchWord } = req.params
+	const { w: searchWord } = req.query
 
 	const result = await getTagsByWordWithForwardMatch(CosmosClient)(searchWord)
 

--- a/user-info/index.ts
+++ b/user-info/index.ts
@@ -3,17 +3,7 @@ import { AzureFunction, Context, HttpRequest } from '@azure/functions'
 import { CosmosClient } from '@azure/cosmos'
 import Web3 from 'web3'
 import { User, reader, writer } from './db'
-
-const responseCreator = (context: Context) => (
-	status = 200,
-	body: string | Record<string, unknown> = ''
-) => {
-	// eslint-disable-next-line functional/immutable-data, functional/no-expression-statement
-	context.res = {
-		status,
-		body,
-	}
-}
+import { responseCreator } from '../utils'
 
 export const httpTrigger: AzureFunction = async function (
 	context: Context,

--- a/utils.ts
+++ b/utils.ts
@@ -1,5 +1,6 @@
 import { Context } from '@azure/functions'
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const responseCreator = (context: Context) => (
 	status = 200,
 	body: string | Record<string, unknown> = ''

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,12 @@
+import { Context } from '@azure/functions'
+
+export const responseCreator = (context: Context) => (
+	status = 200,
+	body: string | Record<string, unknown> = ''
+) => {
+	// eslint-disable-next-line functional/immutable-data, functional/no-expression-statement
+	context.res = {
+		status,
+		body,
+	}
+}


### PR DESCRIPTION
## What's that
Endpoint for tagging to properties.
Tag is seperate with a blank ` ` (So can't use whitespace as a character in a tag)

related issue: #12 

## change summary
* add 4 endpoints (Azure Functions HTTP Trigger)
  * GET `/property/{PROPERTY}/tags`: get tags associated with the property
  * POST `/property/{PROPERTY}/tags`: edit of property's tags with auth
  * GET `/tags?w={WORD}`: return all tags that begin with the letter `WORD` (forward match)
  * POST `/properties/search/tags`: search property with tag(s)
* add `Tag` and `PropertyTags` containers on CosmosDB

## review point
* `Tag` and `PropertyTags` data design
* Are the necessary endpoints implemented?

## TODO
* [x] add more unit test case
* [x] refactoring