### PR TITLE
add social media links for property content type

### DIFF
--- a/api/property/models/property.settings.json
+++ b/api/property/models/property.settings.json
@@ -34,6 +34,11 @@
 			"allowedTypes": ["images", "files", "videos"],
 			"plugin": "upload",
 			"required": false
+		},
+		"links": {
+			"type": "component",
+			"repeatable": false,
+			"component": "url.asset-links"
 		}
 	}
 }

--- a/components/url/asset-links.json
+++ b/components/url/asset-links.json
@@ -1,0 +1,20 @@
+{
+	"collectionName": "components_url_urls",
+	"info": {
+		"name": "Asset_links",
+		"icon": "link",
+		"description": ""
+	},
+	"options": {},
+	"attributes": {
+		"github": {
+			"type": "string"
+		},
+		"twitter": {
+			"type": "string"
+		},
+		"website": {
+			"type": "string"
+		}
+	}
+}


### PR DESCRIPTION
## Why?
add social media links in assert property page on Stakes.social

related issue: https://github.com/dev-protocol/stakes.social/pull/753