### PR TITLE
Auth delete method

### DIFF
--- a/middlewares/web3SignRecover/index.js
+++ b/middlewares/web3SignRecover/index.js
@@ -10,7 +10,7 @@ module.exports = (strapi) => {
 				const { authorization } = ctx.request.headers
 				if (!authorization) {
 					if (
-						(ctx.method === 'POST' || ctx.method === 'PUT') &&
+						(ctx.method === 'POST' || ctx.method === 'PUT' || ctx.method === 'DELETE') &&
 						(ctx.url.startsWith('/accounts') ||
 							ctx.url.startsWith('/properties') ||
 							ctx.url === '/upload')

--- a/middlewares/web3SignRecover/index.js
+++ b/middlewares/web3SignRecover/index.js
@@ -10,7 +10,9 @@ module.exports = (strapi) => {
 				const { authorization } = ctx.request.headers
 				if (!authorization) {
 					if (
-						(ctx.method === 'POST' || ctx.method === 'PUT' || ctx.method === 'DELETE') &&
+						(ctx.method === 'POST' ||
+							ctx.method === 'PUT' ||
+							ctx.method === 'DELETE') &&
 						(ctx.url.startsWith('/accounts') ||
 							ctx.url.startsWith('/properties') ||
 							ctx.url === '/upload')


### PR DESCRIPTION
# why 
File deletion and content deletion must be done with the DELETE method, which should also be authenticated.