### PR TITLE
auth with file upload endpoint

### DIFF
--- a/config/middleware.json
+++ b/config/middleware.json
@@ -4,5 +4,16 @@
 		"before": ["responseTime", "logger", "cors", "responses", "gzip"],
 		"order": [],
 		"after": ["parser", "web3SignRecover", "router"]
+	},
+	"settings": {
+		"cors": {
+			"headers": [
+				"Content-Type",
+				"Authorization",
+				"Origin",
+				"Accept",
+				"X-Dev-Auth"
+			]
+		}
 	}
 }

--- a/middlewares/web3SignRecover/index.js
+++ b/middlewares/web3SignRecover/index.js
@@ -1,5 +1,11 @@
 const Web3 = require('web3')
 
+const getXDevAuthToken = (ctx) => {
+	const { 'x-dev-auth': xDevAuth } = ctx.request.headers
+	const [address, signature, ...message] = xDevAuth.split(';')
+	return { signMessage: message.join(';'), signature, address }
+}
+
 module.exports = (strapi) => {
 	return {
 		initialize() {
@@ -17,11 +23,8 @@ module.exports = (strapi) => {
 							ctx.url.startsWith('/properties') ||
 							ctx.url.startsWith('/upload'))
 					) {
-						const {
-							signMessage: message,
-							signature,
-							address,
-						} = ctx.request.body
+						const { signMessage: message, signature, address } =
+							ctx.method === 'DELETE' ? getXDevAuthToken(ctx) : ctx.request.body
 						ctx.log.debug('params: ', message, signature, address)
 						if (!message || !signature || !address) {
 							ctx.response.unauthorized('invalid request')

--- a/middlewares/web3SignRecover/index.js
+++ b/middlewares/web3SignRecover/index.js
@@ -15,7 +15,7 @@ module.exports = (strapi) => {
 							ctx.method === 'DELETE') &&
 						(ctx.url.startsWith('/accounts') ||
 							ctx.url.startsWith('/properties') ||
-							ctx.url === '/upload')
+							ctx.url.startsWith('/upload'))
 					) {
 						const {
 							signMessage: message,


### PR DESCRIPTION
## Why
Continuation of #98 

Make all [strapi file upload endpoints](https://strapi.io/documentation/3.0.0-beta.x/plugins/upload.html#endpoints) auth targets.

## Implementation
* get signature, message, address from `X-Dev-Auth` header
* add middleware config for `X-Dev-Auth` header