### PR TITLE
add PropertySetting content type

### DIFF
--- a/api/property-setting/config/routes.json
+++ b/api/property-setting/config/routes.json
@@ -1,0 +1,52 @@
+{
+	"routes": [
+		{
+			"method": "GET",
+			"path": "/property-settings",
+			"handler": "property-setting.find",
+			"config": {
+				"policies": []
+			}
+		},
+		{
+			"method": "GET",
+			"path": "/property-settings/count",
+			"handler": "property-setting.count",
+			"config": {
+				"policies": []
+			}
+		},
+		{
+			"method": "GET",
+			"path": "/property-settings/:id",
+			"handler": "property-setting.findOne",
+			"config": {
+				"policies": []
+			}
+		},
+		{
+			"method": "POST",
+			"path": "/property-settings",
+			"handler": "property-setting.create",
+			"config": {
+				"policies": []
+			}
+		},
+		{
+			"method": "PUT",
+			"path": "/property-settings/:id",
+			"handler": "property-setting.update",
+			"config": {
+				"policies": []
+			}
+		},
+		{
+			"method": "DELETE",
+			"path": "/property-settings/:id",
+			"handler": "property-setting.delete",
+			"config": {
+				"policies": []
+			}
+		}
+	]
+}

--- a/api/property-setting/controllers/property-setting.js
+++ b/api/property-setting/controllers/property-setting.js
@@ -1,0 +1,8 @@
+'use strict'
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {}

--- a/api/property-setting/models/property-setting.js
+++ b/api/property-setting/models/property-setting.js
@@ -1,0 +1,8 @@
+'use strict'
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {}

--- a/api/property-setting/models/property-setting.settings.json
+++ b/api/property-setting/models/property-setting.settings.json
@@ -1,0 +1,26 @@
+{
+	"kind": "collectionType",
+	"collectionName": "property_settings",
+	"info": {
+		"name": "PropertySetting"
+	},
+	"options": {
+		"increments": true,
+		"timestamps": true,
+		"draftAndPublish": false
+	},
+	"attributes": {
+		"property_address": {
+			"type": "string",
+			"required": true
+		},
+		"account_address": {
+			"type": "string",
+			"required": true
+		},
+		"private_staking": {
+			"type": "boolean",
+			"default": false
+		}
+	}
+}

--- a/api/property-setting/services/property-setting.js
+++ b/api/property-setting/services/property-setting.js
@@ -1,0 +1,8 @@
+'use strict'
+
+/**
+ * Read the documentation (https://strapi.io/documentation/v3.x/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {}

--- a/middlewares/web3SignRecover/index.js
+++ b/middlewares/web3SignRecover/index.js
@@ -21,6 +21,7 @@ module.exports = (strapi) => {
 							ctx.method === 'DELETE') &&
 						(ctx.url.startsWith('/accounts') ||
 							ctx.url.startsWith('/properties') ||
+							ctx.url.startsWith('/property-settings') ||
 							ctx.url.startsWith('/upload'))
 					) {
 						const { signMessage: message, signature, address } =


### PR DESCRIPTION
## Why
It ties `account` and `property` together on a one-to-one basis to hold configuration items.
The most immediate reason is to use it for feature of private staking (incognito mode).

