### PR TITLE
add new column of property_settings component on Account content type

### DIFF
--- a/api/account/models/account.settings.json
+++ b/api/account/models/account.settings.json
@@ -39,6 +39,11 @@
 			"allowedTypes": ["images", "files", "videos"],
 			"plugin": "upload",
 			"required": false
+		},
+		"property_settings": {
+			"type": "component",
+			"repeatable": false,
+			"component": "setting.property-setting"
 		}
 	}
 }

--- a/api/property-setting/models/property-setting.settings.json
+++ b/api/property-setting/models/property-setting.settings.json
@@ -2,7 +2,8 @@
 	"kind": "collectionType",
 	"collectionName": "property_settings",
 	"info": {
-		"name": "PropertySetting"
+		"name": "PropertySetting",
+		"description": ""
 	},
 	"options": {
 		"increments": true,
@@ -14,7 +15,7 @@
 			"type": "string",
 			"required": true
 		},
-		"account_address": {
+		"address": {
 			"type": "string",
 			"required": true
 		},

--- a/components/setting/property-setting.json
+++ b/components/setting/property-setting.json
@@ -1,0 +1,15 @@
+{
+	"collectionName": "components_property_settings",
+	"info": {
+		"name": "Property Setting",
+		"icon": "cogs",
+		"description": ""
+	},
+	"options": {},
+	"attributes": {
+		"private_staking": {
+			"type": "boolean",
+			"default": false
+		}
+	}
+}


### PR DESCRIPTION
## Why
I want to have an account global setting for incognito mode, etc.

refs: https://github.com/dev-protocol/stakes.social/pull/854

## Impl
* add new column of `property_settings` component into `Account` content type
    * `property_settings` component have `private_staking` column
    * this is account global setting for property
* change column name from `account_address` to `address` for authentication

## NOTE
* Probably referring to `PropertySetting` will cause an error when after deploying this chage. can solve it by dropping column of `PropertySetting.account_address`. (I will operate it.)