### PR TITLE
add Incubator collection type

### DIFF
--- a/api/incubator/config/routes.json
+++ b/api/incubator/config/routes.json
@@ -1,0 +1,52 @@
+{
+	"routes": [
+		{
+			"method": "GET",
+			"path": "/incubators",
+			"handler": "incubator.find",
+			"config": {
+				"policies": []
+			}
+		},
+		{
+			"method": "GET",
+			"path": "/incubators/count",
+			"handler": "incubator.count",
+			"config": {
+				"policies": []
+			}
+		},
+		{
+			"method": "GET",
+			"path": "/incubators/:id",
+			"handler": "incubator.findOne",
+			"config": {
+				"policies": []
+			}
+		},
+		{
+			"method": "POST",
+			"path": "/incubators",
+			"handler": "incubator.create",
+			"config": {
+				"policies": []
+			}
+		},
+		{
+			"method": "PUT",
+			"path": "/incubators/:id",
+			"handler": "incubator.update",
+			"config": {
+				"policies": []
+			}
+		},
+		{
+			"method": "DELETE",
+			"path": "/incubators/:id",
+			"handler": "incubator.delete",
+			"config": {
+				"policies": []
+			}
+		}
+	]
+}

--- a/api/incubator/controllers/incubator.js
+++ b/api/incubator/controllers/incubator.js
@@ -1,0 +1,8 @@
+'use strict'
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/controllers.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {}

--- a/api/incubator/models/incubator.js
+++ b/api/incubator/models/incubator.js
@@ -1,0 +1,8 @@
+'use strict'
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {}

--- a/api/incubator/models/incubator.settings.json
+++ b/api/incubator/models/incubator.settings.json
@@ -1,0 +1,20 @@
+{
+	"kind": "collectionType",
+	"collectionName": "incubators",
+	"info": {
+		"name": "Incubator"
+	},
+	"options": {
+		"increments": true,
+		"timestamps": true,
+		"draftAndPublish": false
+	},
+	"attributes": {
+		"name": {
+			"type": "uid"
+		},
+		"property": {
+			"model": "property"
+		}
+	}
+}

--- a/api/incubator/services/incubator.js
+++ b/api/incubator/services/incubator.js
@@ -1,0 +1,8 @@
+'use strict'
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/services.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {}


### PR DESCRIPTION
## Proposed Changes
for Incubator page.

Add `Incubator`(`Incubators`) to the content type to get the list of incubators.

## Implementation
columns
* name
* property (1:1 relation with `Property`)

endpoint
* get incubator list: `GET /incubators`
